### PR TITLE
change npm name and update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
 # Module for common Java code generation utilities
-| Build | Status |
-| ------ | ---- |
-| development | [![Build Status](https://travis.ibm.com/arf/java-codegen-common.svg?token=D9H1S9JmREZirtqjnxut&branch=development)](https://travis.ibm.com/arf/java-codegen-common) |
-| master | [![Build Status](https://travis.ibm.com/arf/java-codegen-common.svg?token=D9H1S9JmREZirtqjnxut&branch=master)](https://travis.ibm.com/arf/java-codegen-common) |
+[![Build Status](https://travis-ci.org/ibm-developer/java-codegen-common.svg?branch=master)](https://travis-ci.org/ibm-developer/java-codegen-common/branches)
 
-You can see builds for all branches here https://travis.ibm.com/arf/java-codegen-common/branches.
+You can see builds for all branches here [https://travis-ci.org/ibm-developer/java-codegen-common/branches](https://travis-ci.org/ibm-developer/java-codegen-common/branches).
 
 This is a module that contains common Java code generation libraries used by various Java generators.
-
-For more information see our [GitHub Enterprise page](https://github.ibm.com/arf/java-codegen-common).

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,6 +1,6 @@
 # IBM Java Codegen Common
 
-[![IBM Cloud powered][img-bluemix-powered]][url-bluemix]
+[![IBM Cloud powered][img-cloud-powered]][url-bluemix]
 [![Travis][img-travis-master]][url-travis-master]
 [![Coveralls][img-coveralls-master]][url-coveralls-master]
 [![Codacy][img-codacy]][url-codacy]
@@ -11,15 +11,15 @@
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 
 
-[img-bluemix-powered]: https://img.shields.io/badge/bluemix-powered-blue.svg
+[img-cloud-powered]: https://img.shields.io/badge/ibmcloud-powered-blue.svg
 [url-bluemix]: http://bluemix.net
-[url-npm]: https://www.npmjs.com/package/java-codegen-common
-[img-license]: https://img.shields.io/npm/l/java-codegen-common.svg
-[img-version]: https://img.shields.io/npm/v/java-codegen-common.svg
-[img-npm-downloads-monthly]: https://img.shields.io/npm/dm/java-codegen-common.svg
-[img-npm-downloads-total]: https://img.shields.io/npm/dt/java-codegen-common.svg
+[url-npm]: https://www.npmjs.com/package/ibm-java-codegen-common
+[img-license]: https://img.shields.io/npm/l/ibm-java-codegen-common.svg
+[img-version]: https://img.shields.io/npm/v/ibm-java-codegen-common.svg
+[img-npm-downloads-monthly]: https://img.shields.io/npm/dm/ibm-java-codegen-common.svg
+[img-npm-downloads-total]: https://img.shields.io/npm/dt/ibm-java-codegen-common.svg
 
-[img-travis-master]: https://travis-ci.org/ibm-developer/java-codegen-common.svg?branch=development
+[img-travis-master]: https://travis-ci.org/ibm-developer/java-codegen-common.svg?branch=master
 [url-travis-master]: https://travis-ci.org/ibm-developer/java-codegen-common/branches
 
 [img-coveralls-master]: https://coveralls.io/repos/github/ibm-developer/java-codegen-common/badge.svg

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "java-codegen-common",
+  "name": "ibm-java-codegen-common",
   "version": "2.3.0",
   "description": "Common Java code generation utilities",
   "license": "Apache-2.0",
@@ -45,6 +45,7 @@
   ],
   "contributors": [
     "Adam Pilkington",
-    "Kate Stanley"
+    "Kate Stanley",
+    "Quan Vo"
   ]
 }


### PR DESCRIPTION
I changed the package name to `ibm-java-codegen-common` and any npm related links in the READMEs.

However other links like travis, codacy, etc were left as `java-codegen-common`. Are these changing as well?